### PR TITLE
fixed duplicate entries issue in .ssh/config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd
 	github.com/pulumi/pulumi-aws/sdk/v4 v4.16.0
 	github.com/pulumi/pulumi-command/sdk v0.0.3
 	github.com/pulumi/pulumi/sdk/v3 v3.14.0


### PR DESCRIPTION
# [Issue #1](https://github.com/slim-ai/mob-code-server/issues/1) Reference

# What

* add usable `config` file parsing and logic

# Why
multiple deploys would make duplicate entries