### PR TITLE
fix cert generation and key file management

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,7 +28,7 @@ func main() {
 		}
 		//
 		// Maybe create new ssh cert if the user didn't provide one in settings
-		if err := crypto.TryCreateMachineSshCertificate(&settings); err != nil {
+		if err := crypto.TryCreateMachineSshCertificate(ctx, &settings); err != nil {
 			return err
 		}
 		/////////////////////////////////////////////////////////////

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,8 @@ require (
 	github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd
 	github.com/pulumi/pulumi-aws/sdk/v4 v4.16.0
 	github.com/pulumi/pulumi-command/sdk v0.0.3
+	github.com/pulumi/pulumi-tls/sdk/v4 v4.1.0
 	github.com/pulumi/pulumi/sdk/v3 v3.14.0
-	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
+	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
 	gopkg.in/yaml.v2 v2.2.8
 )

--- a/go.sum
+++ b/go.sum
@@ -166,6 +166,8 @@ github.com/pulumi/pulumi-aws/sdk/v4 v4.16.0 h1:8DWQx5i9J2t5MxAEAjdBqMaOikvoXmi4T
 github.com/pulumi/pulumi-aws/sdk/v4 v4.16.0/go.mod h1:31LC9pNuxOtzZ7E1/MaSHmeKkU/J9yAWsHjBqZ3GWjI=
 github.com/pulumi/pulumi-command/sdk v0.0.3 h1:APhWyBSjCp94b5VTVPz0GwwhP//HT22CD7cBQ0JhAic=
 github.com/pulumi/pulumi-command/sdk v0.0.3/go.mod h1:WtWndGuQusF2p68t6xEa9yQy6ObMJugKigB2hN4dzts=
+github.com/pulumi/pulumi-tls/sdk/v4 v4.1.0 h1:revpmx5G08vdbqbMLtOmPkp3c/nXGiia6Z2MWWafH30=
+github.com/pulumi/pulumi-tls/sdk/v4 v4.1.0/go.mod h1:MiYAhU5/WMZtTGRzNIN46eYKux9o4DUF0vnFlkB8cf0=
 github.com/pulumi/pulumi/sdk/v3 v3.3.1/go.mod h1:GBHyQ7awNQSRmiKp/p8kIKrGrMOZeA/k2czoM/GOqds=
 github.com/pulumi/pulumi/sdk/v3 v3.7.0/go.mod h1:GBHyQ7awNQSRmiKp/p8kIKrGrMOZeA/k2czoM/GOqds=
 github.com/pulumi/pulumi/sdk/v3 v3.14.0 h1:UXLRHGQCsO1tLWdv4IO3IQOXrUoZUHhDtDXFoGMmAtA=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,9 +40,11 @@ type ConcurrentVersionsSystemInfo struct {
 }
 
 type SshCredentials struct {
-	Created bool   `yaml:"_" json:"_" `
-	Public  string `yaml:"public" json:"public" `
-	Private string `yaml:"private" json:"private"`
+	Created       bool                `yaml:"_" json:"_" `
+	Public        string              `yaml:"public" json:"public" `
+	Private       string              `yaml:"private" json:"private"`
+	PrivateOutput pulumi.StringOutput `yaml:"_" json:"_"`
+	PublicOutput  pulumi.StringOutput `yaml:"_" json:"_"`
 }
 
 func (settings *Settings) Load(ctx *pulumi.Context) error {

--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -1,93 +1,74 @@
 package crypto
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/x509"
-	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
 
 	"github.com/kevinburke/ssh_config"
+	"github.com/pulumi/pulumi-command/sdk/go/command/local"
+	"github.com/pulumi/pulumi-tls/sdk/v4/go/tls"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/slim-ai/mob-code-server/pkg/config"
-	"golang.org/x/crypto/ssh"
 )
-
-// generatePrivateKey creates a RSA Private Key of specified byte size
-func GeneratePrivateKey(bitSize int) (*rsa.PrivateKey, error) {
-	// Private Key generation
-	privateKey, err := rsa.GenerateKey(rand.Reader, bitSize)
-	if err != nil {
-		return nil, err
-	}
-	// Validate Private Key
-	err = privateKey.Validate()
-	if err != nil {
-		return nil, err
-	}
-	return privateKey, nil
-}
-
-// encodePrivateKeyToPEM encodes Private Key from RSA to PEM format
-func EncodePrivateKeyToPEM(privateKey *rsa.PrivateKey) []byte {
-	// Get ASN.1 DER format
-	privDER := x509.MarshalPKCS1PrivateKey(privateKey)
-	// pem.Block
-	privBlock := pem.Block{
-		Type:    "RSA PRIVATE KEY",
-		Headers: nil,
-		Bytes:   privDER,
-	}
-	// Private key in PEM format
-	privatePEM := pem.EncodeToMemory(&privBlock)
-	return privatePEM
-}
-
-// generatePublicKey take a rsa.PublicKey and return bytes suitable for writing to .pub file
-// returns in the format "ssh-rsa ..."
-func GeneratePublicKey(privatekey *rsa.PublicKey) ([]byte, error) {
-	publicRsaKey, err := ssh.NewPublicKey(privatekey)
-	if err != nil {
-		return nil, err
-	}
-	pubKeyBytes := ssh.MarshalAuthorizedKey(publicRsaKey)
-	return pubKeyBytes, nil
-}
 
 // TryCreateMachineSshCertificate - creates a Cert for SSH access of the new machine
 // if the user didn't provide one in settings
-func TryCreateMachineSshCertificate(settings *config.Settings) error {
-	if settings.MachineInfo.Credentials.Public == "" {
-		privKey, err := GeneratePrivateKey(2048)
-		if err != nil {
+func TryCreateMachineSshCertificate(ctx *pulumi.Context, settings *config.Settings) error {
+	sshDirectory := path.Clean(path.Join(os.Getenv("HOME"), ".ssh"))
+	if _, err := os.Stat(sshDirectory); !os.IsNotExist(err) {
+		if err := os.MkdirAll(sshDirectory, 0700); err != nil {
 			return err
 		}
-		pubKey, err := GeneratePublicKey(&privKey.PublicKey)
-		if err != nil {
-			return err
-		}
-		keyBytes := EncodePrivateKeyToPEM(privKey)
-		settings.MachineInfo.Credentials.Private = string(keyBytes)
-		settings.MachineInfo.Credentials.Public = string(pubKey)
-		settings.MachineInfo.Credentials.Created = true
+	}
 
-		//
-		// Now write out to file
-		sshDirectory := path.Clean(path.Join(os.Getenv("HOME"), ".ssh"))
-		if _, err := os.Stat(sshDirectory); !os.IsNotExist(err) {
-			if err := os.MkdirAll(sshDirectory, 0700); err != nil {
-				return err
-			}
-		}
-		if err := WriteKeyToFile(keyBytes, path.Join(sshDirectory, settings.DomainName)); err != nil {
+	if settings.MachineInfo.Credentials.Public == "" && settings.MachineInfo.Credentials.Private == "" {
+		key, err := tls.NewPrivateKey(ctx,
+			settings.DomainName,
+			&tls.PrivateKeyArgs{
+				Algorithm: pulumi.String("RSA"),
+				RsaBits:   pulumi.IntPtr(4096),
+			},
+		)
+		if err != nil {
 			return err
 		}
-		if err := tryWriteSshConfigFile(settings.MachineInfo.UserName, sshDirectory, settings.DomainName); err != nil {
+		if _, err := local.NewCommand(ctx,
+			"private-ssh-key-writer",
+			&local.CommandArgs{
+				Create: pulumi.Sprintf("echo '%s' > %s/%s", key.PrivateKeyPem, sshDirectory, settings.DomainName),
+				Delete: pulumi.Sprintf("rm -f %s/%s", sshDirectory, settings.DomainName),
+			},
+			pulumi.DependsOn([]pulumi.Resource{key}),
+		); err != nil {
 			return err
 		}
+		if _, err := local.NewCommand(ctx,
+			"public-ssh-key-writer",
+			&local.CommandArgs{
+				Create: pulumi.Sprintf("echo '%s' > %s/%s.pub", key.PublicKeyOpenssh, sshDirectory, settings.DomainName),
+				Delete: pulumi.Sprintf("rm -f %s/%s.pub", sshDirectory, settings.DomainName),
+			},
+			pulumi.DependsOn([]pulumi.Resource{key}),
+		); err != nil {
+			return err
+		}
+		settings.MachineInfo.Credentials.PrivateOutput = pulumi.Sprintf("%s", key.PrivateKeyPem)
+		settings.MachineInfo.Credentials.PublicOutput = pulumi.Sprintf("%s", key.PublicKeyOpenssh)
+		settings.MachineInfo.Credentials.Created = true
+	} else {
+		privateKey := pulumi.String(settings.MachineInfo.Credentials.Private)
+		settings.MachineInfo.Credentials.PrivateOutput = privateKey.ToStringOutput().ApplyT(func(s string) string {
+			return s
+		}).(pulumi.StringOutput)
+		publicKey := pulumi.String(settings.MachineInfo.Credentials.Public)
+		settings.MachineInfo.Credentials.PublicOutput = publicKey.ToStringOutput().ApplyT(func(s string) string {
+			return s
+		}).(pulumi.StringOutput)
+	}
+	if err := tryWriteSshConfigFile(settings.MachineInfo.UserName, sshDirectory, settings.DomainName); err != nil {
+		return err
 	}
 	return nil
 }
@@ -137,15 +118,6 @@ func tryWriteSshConfigFile(username string, sshDirectory string, certFileName st
 	newConfigFile = strings.ReplaceAll(newConfigFile, "__USERNAME__", "ubuntu")
 	newConfigFile = strings.ReplaceAll(newConfigFile, "__CERTFILEPATH__", path.Join(sshDirectory, certFileName))
 	if _, err = f.WriteString(newConfigFile); err != nil {
-		return err
-	}
-	return nil
-}
-
-// writePemToFile writes keys to a file
-func WriteKeyToFile(keyBytes []byte, saveFileTo string) error {
-	err := ioutil.WriteFile(saveFileTo, keyBytes, 0600)
-	if err != nil {
 		return err
 	}
 	return nil

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -100,7 +100,7 @@ func CreateNewKeyPair(ctx *pulumi.Context, settings *config.Settings) (*ec2.KeyP
 	return ec2.NewKeyPair(ctx, name,
 		&ec2.KeyPairArgs{
 			KeyName:   pulumi.String(name),
-			PublicKey: pulumi.String(settings.MachineInfo.Credentials.Public),
+			PublicKey: settings.MachineInfo.Credentials.PublicOutput,
 			Tags: pulumi.StringMap{
 				"Owner": pulumi.String(settings.MachineInfo.Hostname),
 			},

--- a/pkg/userdata/userdata.go
+++ b/pkg/userdata/userdata.go
@@ -40,7 +40,7 @@ func RunProvisioningScripts(ctx *pulumi.Context, settings *config.Settings,
 				Connection: remote.ConnectionArgs{
 					Host:       pulumi.String(settings.DomainName),
 					Port:       pulumi.Float64(22),
-					PrivateKey: pulumi.String(settings.MachineInfo.Credentials.Private),
+					PrivateKey: settings.MachineInfo.Credentials.PrivateOutput,
 					User:       pulumi.String(defaultUser),
 				},
 				Create: pulumi.StringPtr(createResolvedText),


### PR DESCRIPTION
# [ISSUE #3](https://github.com/slim-ai/mob-code-server/issues/3) Reference

# Why
To prevent resource thrashing and recreation due to SSH key generation.

# What
Used a combination of `pulumi-tls` and `pulumi-command/local` to control the generation and management of the SSH key. By using this approach we have pulumi manage the key and key state; which prevents from redeploys because the key used to be regenerated every time.
Also - this simplifies the code (A+)

# How tested

Ran the following sequence 3 times:
```
make deploy
```

## Result
* No change, no modification of resources on deployment
* Key files deleted correctly on destroy
   